### PR TITLE
Fixed quotation marks on color values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "themer-tmux",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2597,14 +2597,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2613,6 +2605,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4803,15 +4803,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4828,6 +4819,15 @@
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -4957,21 +4957,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
-    },
-    "tmux-colors": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tmux-colors/-/tmux-colors-0.0.2.tgz",
-      "integrity": "sha1-vX/rvd8i3ZBpnUVElAMqKzdfvek=",
-      "requires": {
-        "ansi-styles": "1.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-        }
-      }
     },
     "to-fast-properties": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themer-tmux",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "tmux template for themer.",
   "main": "lib/index.js",
   "engines": {

--- a/src/layouts/block.js
+++ b/src/layouts/block.js
@@ -23,8 +23,8 @@ set -g status-left-length 40
 set -g status-left "#[fg=${colorSet.shade0},bg=${colorSet[`accent${i * 2}`]},bold] #S #[fg=${colorSet[`accent${i * 2}`]},bg=${colorSet.shade4},nobold]#[fg=${colorSet.shade1},bg=${colorSet.shade4}] #(whoami) #[fg=${colorSet.shade4},bg=${colorSet.shade2}]#[fg=${colorSet.shade4},bg=${colorSet.shade2}] #I:#P #[fg=${colorSet.shade2},bg=${colorSet.shade1},nobold]"
 
 # Right side of status bar
-set -g status-right-bg ${colorSet.shade1}
-set -g status-right-fg ${colorSet.shade5}
+set -g status-right-bg "${colorSet.shade1}"
+set -g status-right-fg "${colorSet.shade5}"
 set -g status-right-length 150
 set -g status-right "#[fg=${colorSet.shade2},bg=${colorSet.shade1}]#[fg=${colorSet.shade4},bg=${colorSet.shade2}] %H:%M:%S #[fg=${colorSet.shade4},bg=${colorSet.shade2}]#[fg=${colorSet.shade1},bg=${colorSet.shade4}] %d-%b-%y #[fg=${colorSet.shade6},bg=${colorSet.shade4}]#[fg=${colorSet.shade0},bg=${colorSet.shade6},bold] #H "
 
@@ -33,12 +33,12 @@ set -g window-status-format "#[fg=${colorSet.shade7}]#[bg=${colorSet.shade1}] #I
 set -g window-status-current-format "#[fg=${colorSet[`accent${i * 2 + 1}`]},bg=black] #I:#W#F "
 
 # Current window status
-set -g window-status-current-bg ${colorSet[`accent${i * 2}`]}
-set -g window-status-current-fg ${colorSet.shade0}
+set -g window-status-current-bg "${colorSet[`accent${i * 2}`]}"
+set -g window-status-current-fg "${colorSet.shade0}"
 
 # Window with activity status
-set -g window-status-activity-bg ${colorSet[`accent${i * 2 + 1}`]}  # fg and bg are flipped here due to
-set -g window-status-activity-fg ${colorSet.shade1} # a bug in tmux
+set -g window-status-activity-bg "${colorSet[`accent${i * 2 + 1}`]}"  # fg and bg are flipped here due to
+set -g window-status-activity-fg "${colorSet.shade1}" # a bug in tmux
 
 # Window separator
 set -g window-status-separator ""
@@ -48,28 +48,29 @@ set -g status-justify centre
 
 # Pane border
 set -g pane-border-bg default
-set -g pane-border-fg ${colorSet.shade3}
+set -g pane-border-fg "${colorSet.shade3}"
 
 # Active pane border
 set -g pane-active-border-bg default
-set -g pane-active-border-fg ${colorSet[`accent${i * 2}`]}
+set -g pane-active-border-fg "${colorSet[`accent${i * 2}`]}"
 
 # Pane number indicator
-set -g display-panes-colour ${colorSet.shade1}
-set -g display-panes-active-colour ${colorSet.shade6}
+set -g display-panes-colour "${colorSet.shade1}"
+set -g display-panes-active-colour "${colorSet.shade6}"
 
 # Clock mode
-set -g clock-mode-colour ${colorSet[`accent${i * 2}`]}
+set -g clock-mode-colour "${colorSet[`accent${i * 2}`]}"
 set -g clock-mode-style 24
 
 # Message
-set -g message-bg ${colorSet[`accent${i * 2}`]}
+set -g message-bg "${colorSet[`accent${i * 2}`]}"
 set -g message-fg black
 
 # Command message
-set -g message-command-bg ${colorSet.shade1}
+set -g message-command-bg "${colorSet.shade1}"
 set -g message-command-fg black
 
 # Mode
-set -g mode-bg ${colorSet[`accent${i * 2}`]}
-set -g mode-fg ${colorSet.shade7}`;
+set -g mode-bg "${colorSet[`accent${i * 2}`]}"
+set -g mode-fg "${colorSet.shade7}"
+`;

--- a/src/layouts/default.js
+++ b/src/layouts/default.js
@@ -23,8 +23,8 @@ set -g status-left-length 40
 set -g status-left "#[fg=${colorSet.shade0},bg=${colorSet[`accent${i * 2}`]},bold] #S #[fg=${colorSet[`accent${i * 2}`]},bg=${colorSet.shade4},nobold]#[fg=${colorSet.shade1},bg=${colorSet.shade4}] #(whoami) #[fg=${colorSet.shade4},bg=${colorSet.shade2}]#[fg=${colorSet.shade4},bg=${colorSet.shade2}] #I:#P #[fg=${colorSet.shade2},bg=${colorSet.shade1},nobold]"
 
 # Right side of status bar
-set -g status-right-bg ${colorSet.shade1}
-set -g status-right-fg ${colorSet.shade5}
+set -g status-right-bg "${colorSet.shade1}"
+set -g status-right-fg "${colorSet.shade5}"
 set -g status-right-length 150
 set -g status-right "#[fg=${colorSet.shade2},bg=${colorSet.shade1}]#[fg=${colorSet.shade4},bg=${colorSet.shade2}] %H:%M:%S #[fg=${colorSet.shade4},bg=${colorSet.shade2}]#[fg=${colorSet.shade1},bg=${colorSet.shade4}] %d-%b-%y #[fg=${colorSet.shade6},bg=${colorSet.shade4}]#[fg=${colorSet.shade0},bg=${colorSet.shade6},bold] #H "
 
@@ -33,12 +33,12 @@ set -g window-status-format "#[fg=${colorSet.shade7}]#[bg=${colorSet.shade1}]  #
 set -g window-status-current-format "#[fg=${colorSet.shade1},bg=black]#[fg=${colorSet[`accent${i * 2 + 1}`]},nobold] #I:#W#F #[fg=${colorSet.shade1},bg=black,nobold]"
 
 # Current window status
-set -g window-status-current-bg ${colorSet[`accent${i * 2}`]}
-set -g window-status-current-fg ${colorSet.shade2}
+set -g window-status-current-bg "${colorSet[`accent${i * 2}`]}"
+set -g window-status-current-fg "${colorSet.shade2}"
 
 # Window with activity status
-set -g window-status-activity-bg ${colorSet.shade6} # fg and bg are flipped here due to
-set -g window-status-activity-fg ${colorSet.shade1} # a bug in tmux
+set -g window-status-activity-bg "${colorSet.shade6}" # fg and bg are flipped here due to
+set -g window-status-activity-fg "${colorSet.shade1}" # a bug in tmux
 
 # Window separator
 set -g window-status-separator ""
@@ -48,28 +48,28 @@ set -g status-justify centre
 
 # Pane border
 set -g pane-border-bg default
-set -g pane-border-fg ${colorSet.shade3}
+set -g pane-border-fg "${colorSet.shade3}"
 
 # Active pane border
 set -g pane-active-border-bg default
-set -g pane-active-border-fg ${colorSet[`accent${i * 2}`]}
+set -g pane-active-border-fg "${colorSet[`accent${i * 2}`]}"
 
 # Pane number indicator
-set -g display-panes-colour ${colorSet.shade1}
-set -g display-panes-active-colour ${colorSet.shade6}
+set -g display-panes-colour "${colorSet.shade1}"
+set -g display-panes-active-colour "${colorSet.shade6}"
 
 # Clock mode
-set -g clock-mode-colour ${colorSet[`accent${i * 2}`]}
+set -g clock-mode-colour "${colorSet[`accent${i * 2}`]}"
 set -g clock-mode-style 24
 
 # Message
-set -g message-bg ${colorSet[`accent${i * 2}`]}
+set -g message-bg "${colorSet[`accent${i * 2}`]}"
 set -g message-fg black
 
 # Command message
-set -g message-command-bg ${colorSet.shade1}
+set -g message-command-bg "${colorSet.shade1}"
 set -g message-command-fg black
 
 # Mode
-set -g mode-bg ${colorSet[`accent${i * 2}`]}
-set -g mode-fg ${colorSet.shade7}`;
+set -g mode-bg "${colorSet[`accent${i * 2}`]}"
+set -g mode-fg "${colorSet.shade7}"`;


### PR DESCRIPTION
`tmux` was complaing about empty values when loading a theme. Upon watching the generated `.tmuxtheme` files by `themer-tmux` i discovered that not all color values were being surrounded by quotation marks. I tested it and now tmux does not complain anymore and all works fine.